### PR TITLE
fix: parameters in overview and url in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Using SSH:
 $ USE_SSH=true yarn deploy
 ```
 
-http://docs.thingspanel.io/
+http://thingspanel.io/
 
 2.0搭建  查看在package.json  
     @docusaurus/core": "2.0.0-rc.1",

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,4 +1,3 @@
-
 ---
 sidebar_position: 1
 ---


### PR DESCRIPTION
`docs/overview.md` 文件开头多出一个空行，导致参数无法正常识别，CI运行出错(https://github.com/ThingsPanel/thingspanel.github.io/actions/runs/4700177633/jobs/8334522517 )，已修复。

顺便发现 `README.md` 中的链接有误，已更改为 http://thingspanel.io/